### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Macroeconomics Newsletter Website
 
-This site provides an AI-powered macroeconomics newsletter with a free beta subscription. The site uses vanilla HTML, Tailwind CSS, and minimal JavaScript with an Express.js server for dynamic deployment.
+This site provides an AI-powered macroeconomics newsletter with a free beta subscription. The site uses vanilla HTML, Tailwind CSS, and minimal JavaScript with an Express.js server for dynamic deployment. It now supports a user-selectable dark mode.
 
 A demo article is available at `article.html` so readers can preview the content before subscribing.
 

--- a/public/article.html
+++ b/public/article.html
@@ -18,6 +18,7 @@
     <meta property="og:description" content="Weekly insights that simplify complex economic concepts using AI">
     <meta property="og:type" content="website">
     <title>AI-Powered Macroeconomics Newsletter - Demo Article</title>
+    <script>tailwind={config:{darkMode:'class'}};</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
@@ -30,6 +31,7 @@
                 <a href="index.html" class="mr-6">Home</a>
                 <a href="subscribe.html" class="btn-secondary">Subscribe</a>
             </nav>
+            <button id="theme-toggle" class="ml-4" aria-label="Toggle theme"><i data-lucide="moon"></i></button>
             <button class="md:hidden" aria-label="Open Menu" onclick="toggleMobileMenu()">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
             </button>

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -15,3 +15,12 @@
 /* Responsive utilities */
 @media (max-width:768px){.card{margin-bottom:1rem;}}
 @media (min-width:1024px){.hero-lg-text{font-size:3rem;}}
+
+/* Dark mode */
+html.dark body{background-color:#0f172a;color:#e2e8f0;}
+html.dark .bg-white{background-color:#1e293b!important;}
+html.dark .bg-slate-50{background-color:#0f172a!important;}
+html.dark .text-slate-800{color:#e2e8f0!important;}
+html.dark .card{background-color:#1e293b;color:#e2e8f0;}
+html.dark footer{background-color:#1e293b;color:#e2e8f0;}
+html.dark .gradient-bg{background:linear-gradient(90deg,#1e293b,#0d9488);}

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -2,4 +2,5 @@ function toggleMobileMenu(){const m=document.getElementById('mobile-menu');m.cla
 function initSmoothScrolling(){document.querySelectorAll('a[href^="#"]').forEach(a=>{a.addEventListener('click',e=>{e.preventDefault();document.querySelector(a.getAttribute('href')).scrollIntoView({behavior:'smooth'});});});}
 function showLoading(e){e.disabled=true;e.classList.add('opacity-50','cursor-not-allowed');}
 function hideLoading(e){e.disabled=false;e.classList.remove('opacity-50','cursor-not-allowed');}
-document.addEventListener('DOMContentLoaded',()=>{initSmoothScrolling();});
+function initThemeToggle(){const b=document.getElementById('theme-toggle');if(!b)return;const s=()=>{b.innerHTML=document.documentElement.classList.contains('dark')?'<i data-lucide="sun"></i>':'<i data-lucide="moon"></i>';lucide.createIcons();};b.addEventListener('click',()=>{document.documentElement.classList.toggle('dark');localStorage.setItem('theme',document.documentElement.classList.contains('dark')?'dark':'light');s();});if(localStorage.getItem('theme')==='dark'){document.documentElement.classList.add('dark');}s();}
+document.addEventListener('DOMContentLoaded',()=>{initSmoothScrolling();initThemeToggle();});

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
     <meta property="og:description" content="Weekly insights that simplify complex economic concepts using AI">
     <meta property="og:type" content="website">
     <title>AI-Powered Macroeconomics Newsletter - Free Beta</title>
+    <script>tailwind={config:{darkMode:'class'}};</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
@@ -30,6 +31,7 @@
                 <a href="index.html" class="mr-6">Home</a>
                 <a href="subscribe.html" class="btn-secondary">Subscribe</a>
             </nav>
+            <button id="theme-toggle" class="ml-4" aria-label="Toggle theme"><i data-lucide="moon"></i></button>
             <button class="md:hidden" aria-label="Open Menu" onclick="toggleMobileMenu()">
                 <svg id="menu-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
             </button>

--- a/public/subscribe.html
+++ b/public/subscribe.html
@@ -18,6 +18,7 @@
     <meta property="og:description" content="Weekly insights that simplify complex economic concepts using AI">
     <meta property="og:type" content="website">
     <title>AI-Powered Macroeconomics Newsletter - Free Beta</title>
+    <script>tailwind={config:{darkMode:'class'}};</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
@@ -30,6 +31,7 @@
                 <a href="index.html" class="mr-6">Home</a>
                 <a href="subscribe.html" class="btn-secondary">Subscribe</a>
             </nav>
+            <button id="theme-toggle" class="ml-4" aria-label="Toggle theme"><i data-lucide="moon"></i></button>
             <button class="md:hidden" aria-label="Open Menu" onclick="toggleMobileMenu()">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
             </button>

--- a/public/success.html
+++ b/public/success.html
@@ -18,6 +18,7 @@
     <meta property="og:description" content="Weekly insights that simplify complex economic concepts using AI">
     <meta property="og:type" content="website">
     <title>AI-Powered Macroeconomics Newsletter - Free Beta</title>
+    <script>tailwind={config:{darkMode:'class'}};</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
@@ -30,6 +31,7 @@
                 <a href="index.html" class="mr-6">Home</a>
                 <a href="subscribe.html" class="btn-secondary">Subscribe</a>
             </nav>
+            <button id="theme-toggle" class="ml-4" aria-label="Toggle theme"><i data-lucide="moon"></i></button>
             <button class="md:hidden" aria-label="Open Menu" onclick="toggleMobileMenu()">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
             </button>


### PR DESCRIPTION
## Summary
- add toggle button and persistence script
- support dark mode styles
- load Tailwind in class-based dark mode
- mention dark mode in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859b72e3a20833299d43e6d6b1278d6